### PR TITLE
chore(deps): update androidx.core:core-ktx to 1.19.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,15 @@ ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
 }
 
+// Hilt 2.59.2 bundles kotlin-metadata-jvm that only reads up to metadata format 2.3.0.
+// Force 2.4.0 so Hilt's KSP processor can parse classes compiled by Kotlin 2.4.0.
+// Remove this block once Hilt releases native support for Kotlin 2.4.0 metadata.
+configurations.all {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.4.0")
+    }
+}
+
 dependencies {
     // Compose BOM
     val composeBom = platform("androidx.compose:compose-bom:2026.05.01")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "dev.dericbourg.firstclassmetronome"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "dev.dericbourg.firstclassmetronome"
@@ -101,7 +101,7 @@ dependencies {
     ksp("com.google.dagger:hilt-compiler:2.59.2")
 
     // Core
-    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.core:core-ktx:1.19.0")
 
     // DataStore
     implementation("androidx.datastore:datastore-preferences:1.2.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
     id("com.google.dagger.hilt.android") version "2.59.2" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
-    id("org.jetbrains.kotlin.plugin.parcelize") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.0" apply false
+    id("org.jetbrains.kotlin.plugin.parcelize") version "2.4.0" apply false
     id("com.google.devtools.ksp") version "2.3.9" apply false
 }


### PR DESCRIPTION
- bump androidx.core:core-ktx from 1.18.0 to 1.19.0
- bump compileSdk from 36 to 37 (required by core-ktx 1.19.0)

Closes #107
Closes #108